### PR TITLE
Update swiss channel description

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -48,7 +48,7 @@ Join our [Discord](https://discord.gg/MBCnqSf) and start with [Salty Chat](https
 * Global overwriting of sounds (`%appdata%\TS3Client\plugins\SaltyChat\override`)
 * Fallback if a file is missing (override > specified sound pack > default sound pack)
 
-# Swiss Channels
+## Swiss Channels
 In the [configuration file](https://github.com/saltminede/saltychat-docs/blob/master/setup.md#swisschannelids) there is the possibility to declare TeamSpeak channels as swiss channels.\
 Swiss channels are channels in which the plugin keeps the original name of the client and does not move them to the ingame channel.
 

--- a/readme.md
+++ b/readme.md
@@ -48,6 +48,14 @@ Join our [Discord](https://discord.gg/MBCnqSf) and start with [Salty Chat](https
 * Global overwriting of sounds (`%appdata%\TS3Client\plugins\SaltyChat\override`)
 * Fallback if a file is missing (override > specified sound pack > default sound pack)
 
+# Swiss Channels
+In the [configuration file](https://github.com/saltminede/saltychat-docs/blob/master/setup.md#swisschannelids) there is the possibility to declare TeamSpeak channels as swiss channels.\
+Swiss channels are channels in which the plugin keeps the original name of the client and does not move them to the ingame channel.
+
+If a client leaves the [ingame channel](https://github.com/saltminede/saltychat-docs/blob/master/setup.md#ingamechannelid) and enters a swiss channel, the plugin will change the clients TeamSpeak name back to its origin and won't move the client to the ingame channel as long as it is in a swiss channel.
+
+Note: The ingame channel should not be declared as a swiss channel, otherwise the clients won't be moved out of it after disconnecting from the server.
+
 # Configuration file
 When the plugin is starting, the configuration file under `%appdata%\TS3Client\plugins\SaltyChat\settings.json` will be loaded an applied.
 Here are various options that can be customized:

--- a/readme.md
+++ b/readme.md
@@ -49,12 +49,11 @@ Join our [Discord](https://discord.gg/MBCnqSf) and start with [Salty Chat](https
 * Fallback if a file is missing (override > specified sound pack > default sound pack)
 
 ## Swiss Channels
-In the [configuration file](https://github.com/saltminede/saltychat-docs/blob/master/setup.md#swisschannelids) there is the possibility to declare TeamSpeak channels as swiss channels.\
-Swiss channels are channels in which the plugin keeps the original name of the client and does not move them to the ingame channel.
+In the [initiate command](https://github.com/saltminede/saltychat-docs/blob/master/commands.md#1--initiate) there is the possibility to declare TeamSpeak channels as swiss channels.\
+Swiss channels are channels in which the plugin keeps the original name of the client and does not move them to the ingame channel.\
+As example for swiss channels you can declare support channels to swiss channels. This gives you the opportunity to move users out of the ingame channel without the need for them to leave the game at first.
 
-If a client leaves the [ingame channel](https://github.com/saltminede/saltychat-docs/blob/master/setup.md#ingamechannelid) and enters a swiss channel, the plugin will change the clients TeamSpeak name back to its origin and won't move the client to the ingame channel as long as it is in a swiss channel.
-
-Note: The ingame channel should not be declared as a swiss channel, otherwise the clients won't be moved out of it after disconnecting from the server.
+If a client leaves the ingame channel and enters a swiss channel, the plugin will change the clients TeamSpeak name back to its origin and won't move the client to the ingame channel as long as it is in a swiss channel.
 
 # Configuration file
 When the plugin is starting, the configuration file under `%appdata%\TS3Client\plugins\SaltyChat\settings.json` will be loaded an applied.

--- a/setup.md
+++ b/setup.md
@@ -31,7 +31,10 @@ Password of the TeamSpeak channel.
 [setup-channel-id]: https://github.com/saltminede/saltychat-docs/raw/master/media/setup-channel-id.jpg "TeamSpeak Channel ID"
 
 ## SwissChannelIds
-IDs of neutral channels that can be joined, while the game instance is running.  
-While moving in one of these channels, the plugin will restore the original TeamSpeak name.  
-The client will be automaticly renamed to the instance name, once the swiss channel is leaved, which also results in a move to the instance channel.
-While being in the swiss channel the plugin won't move the client to the instance channel.
+IDs of the channels that can be entered while the game instance is running, without the client being automatically pushed back to the ingame channel.\
+As soon as the client enters a swiss channel, the original TeamSpeak name is restored.
+
+If the client is in a swiss channel while the game instance is initialized, the plugin will move it to the ingame channel and rename it only after leaving the swiss channel.
+
+Note: If the ingame channel is declared as swiss channel, the player will not be moved to his original channel after disconnecting.
+If the waiting room is declared as a swiss channel, no automatic joining of the ingame channel takes place until the waiting room is left.

--- a/setup.md
+++ b/setup.md
@@ -34,3 +34,4 @@ Password of the TeamSpeak channel.
 IDs of neutral channels that can be joined, while the game instance is running.  
 While moving in one of these channels, the plugin will restore the original TeamSpeak name.  
 The client will be automaticly renamed to the instance name, once the swiss channel is leaved, which also results in a move to the instance channel.
+While being in the swiss channel the plugin won't move the client to the instance channel.

--- a/setup.md
+++ b/setup.md
@@ -31,10 +31,6 @@ Password of the TeamSpeak channel.
 [setup-channel-id]: https://github.com/saltminede/saltychat-docs/raw/master/media/setup-channel-id.jpg "TeamSpeak Channel ID"
 
 ## SwissChannelIds
-IDs of the channels that can be entered while the game instance is running, without the client being automatically pushed back to the ingame channel.\
-As soon as the client enters a swiss channel, the original TeamSpeak name is restored.
-
-If the client is in a swiss channel while the game instance is initialized, the plugin will move it to the ingame channel and rename it only after leaving the swiss channel.
-
-Note: If the ingame channel is declared as swiss channel, the player will not be moved to his original channel after disconnecting.
-If the waiting room is declared as a swiss channel, no automatic joining of the ingame channel takes place until the waiting room is left.
+IDs of neutral channels that can be joined, while the game instance is running.  
+While moving in one of these channels, the plugin will restore the original TeamSpeak name.  
+The client will be automaticly renamed to the instance name, once the swiss channel is leaved, which also results in a move to the instance channel.


### PR DESCRIPTION
Since many people still don't understand that neither the ingame channel nor the waiting room should be declared as swiss channel, I have adapted the description to explicitly point out the functionality and the effects if one of the two channels is declared as swiss channel.